### PR TITLE
fix travis build by upgrading pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ stages:
   - name: deploy
     if: branch = master AND NOT type in (pull_request)
 
+# Control the branches that get built.
+branches:
+  only:
+    - master
+    - /^v[0-9]+\.[0-9]+\.[0-9]+/
+
 # Notify us about build status.
 notifications:
   slack:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,9 @@
 export TWINE_USERNAME=aws
 export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain content-platform --domain-owner 827541288795 --query authorizationToken --output text`
 export TWINE_REPOSITORY_URL=https://content-platform-827541288795.d.codeartifact.us-east-1.amazonaws.com/pypi/content-platform/
+# upgrading pip to resolve dependency issue
+# https://travis-ci.community/t/cant-deploy-to-pypi-anymore-pkg-resources-contextualversionconflict-importlib-metadata-0-18/10494/26
+pip install --upgrade pip
 pip install twine
 python setup.py sdist bdist_wheel
 twine upload --verbose --repository pypodcastparser-ihr dist/*


### PR DESCRIPTION
This PR:
- Fixes our broken travis builds by adding a step to upgrade pip before installing twine.

https://travis-ci.community/t/cant-deploy-to-pypi-anymore-pkg-resources-contextualversionconflict-importlib-metadata-0-18/10494/26