### PR TITLE
include ihr interactive tag in Podcast parser

### DIFF
--- a/pypodcastparser/Podcast.py
+++ b/pypodcastparser/Podcast.py
@@ -57,6 +57,7 @@ class Podcast:
         owner_email (str): Email of feed owner
         subtitle (str): The feed subtitle
         title (str): The feed title
+        interactive (boolean): Is an iheart podcast interactive
     """
 
     def __init__(self, feed_content):
@@ -86,6 +87,7 @@ class Podcast:
         self.title = None
         self.date_time = None
         self.itunes_type = None
+        self.interactive = False
 
         self.set_soup()
         tag_methods = {
@@ -110,6 +112,7 @@ class Podcast:
             ('itunes', 'owner'): self.set_owner,
             ('itunes', 'subtitle'): self.set_subtitle,
             ('itunes', 'summary'): self.set_summary,
+            ('ihr', 'interactive'): self.set_interactive,
         }
         many_tag_methods = set(
             [(None, 'item'), ('itunes', 'category'), ('itunes', 'keywords')]
@@ -384,3 +387,10 @@ class Podcast:
             self.title = tag.string
         except AttributeError:
             self.title = None
+    
+    def set_interactive(self, tag):
+        """Parses ihr-interactive tag and sets true if 'yes' False if otherwise"""
+        try:
+            self.interactive = (tag.string.lower() == "yes")
+        except AttributeError:
+            self.interactive = False

--- a/pypodcastparser/Podcast.py
+++ b/pypodcastparser/Podcast.py
@@ -387,9 +387,9 @@ class Podcast:
             self.title = tag.string
         except AttributeError:
             self.title = None
-    
+
     def set_interactive(self, tag):
-        """Parses ihr-interactive tag and sets true if 'yes' False if otherwise"""
+        """Parses ihr-interactive and set value"""
         try:
             self.interactive = (tag.string.lower() == "yes")
         except AttributeError:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='pypodcastparser-ihr',
 
-    version='1.2.0',
+    version='1.3.0',
 
     description='pypodcastparser is a podcast parser.',
     long_description=long_description,

--- a/tests/test_feeds/ihr_interactive_podcast.rss
+++ b/tests/test_feeds/ihr_interactive_podcast.rss
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rss version="2.0"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:adori="https://adorilabs.com/rss"
+  xmlns:ihr="http://iheart.com/rss/ihr">
+  <channel>
+    <itunes:category text="News">
+			<itunes:category text="Business News"/>
+		</itunes:category>
+		<itunes:category text="Health"/>
+        <copyright>basic copyright</copyright>
+        <description>basic description</description>
+        <generator>an infinite monkeys</generator>
+        <image>
+            <title>Test Image</title>
+            <url>https://test/giffy.jpg</url>
+            <link>https://test</link>
+            <width>1000</width>
+            <height>5000</height>
+        </image>
+        <language>basic  language</language>
+        <lastBuildDate>Mon, 24 Mar 2008 23:30:07 GMT</lastBuildDate>
+        <link>https://github.com/iheartradio/pyPodcastParser</link>]
+        <atom:link href="https://bubpubsubhub.appspot.com" />
+        <atom:link rel="buh" href="https://bubpubsubhub.appspot.com" />
+        <atom:link href="https://pubsubhubbub.appspot.com" />
+
+        <atom:link rel="hub" href="https://pubsubhubbub.appspot.com" />
+
+        <atom:link />
+
+        <atom:link href="https://bubpubsubhub.pspot.com" />
+        <atom:link rel="buh" href="https://bubpubsuhub.appspot.com" />
+        <atom:link href="https://pubsubhbub.appspot.com" />
+        <managingEditor>nobody</managingEditor>
+        <pubDate>Mon, 24 Mar 2008 23:30:07 GMT</pubDate>
+        <title>basic title</title>
+        <ttl>60</ttl>
+        <webMaster>webrobot</webMaster>
+
+        <itunes:author>basic itunes author</itunes:author>
+        <itunes:complete>yes</itunes:complete>
+        <itunes:explicit>clean</itunes:explicit>
+        <itunes:image href="https://github.com/iheartradio/pyPodcastParser.jpg"/>
+        <itunes:keywords>Python, Testing</itunes:keywords>
+        <itunes:new-feed-url>http://newlocation.com/example.rss</itunes:new-feed-url>
+        <itunes:owner>
+            <itunes:email>basic itunes owner email</itunes:email>
+            <itunes:name>basic itunes owner name</itunes:name>
+        </itunes:owner>
+        <itunes:subtitle>basic itunes subtitle</itunes:subtitle>
+        <itunes:summary>basic itunes summary</itunes:summary>
+
+        <item>
+
+            <author>lawyer@boyer.net</author>
+            <category>Grateful Dead</category>
+            <category>Stones</category>
+            <comments>http://comments.com/entry/0</comments>
+            <creativeCommons:license>http://www.creativecommons.org/licenses/by-nc/1.0</creativeCommons:license>
+            <description>basic item description</description>
+            <guid isPermaLink="true">basic item guid</guid>
+            <link>http://google.com/0</link>
+            <pubDate>Fri, 21 Mar 2008 09:51:00 EDT</pubDate>
+            <title>basic item title</title>
+
+            <enclosure length="123456" url="https://github.com/iheartradio/pyPodcastParser.mp3" type="audio/mpeg"/>
+
+            <itunes:author>basic item itunes author</itunes:author>
+            <itunes:isClosedCaptioned>yes</itunes:isClosedCaptioned>
+            <itunes:duration>1:05</itunes:duration>
+            <itunes:explicit>no</itunes:explicit>
+            <itunes:image href="http://poo.poo/gif.jpg"/>
+            <itunes:keywords/>
+            <itunes:order>2</itunes:order>
+            <itunes:subtitle>The Subtitle</itunes:subtitle>
+            <itunes:summary>The Summary</itunes:summary>
+
+
+        </item>
+
+        <item>
+
+            <author>lawyer@boyer.net (Lawyer Boyer)</author>
+            <category>Dead and Grateful</category>
+            <category>News</category>
+            <comments>http://comments.com/entry/1</comments>
+            <description>another basic item description</description>
+            <guid isPermaLink="true">another basic item guid</guid>
+            <link>http://google.com/1</link>
+            <pubDate>Fri, 21 Mar 2008 09:50:00 EDT</pubDate>
+            <title>another basic item title</title>
+
+            <enclosure length="123456" url="https://github.com/iheartradio/pyPodcastParser.mp3" type="audio/mpeg"/>
+
+            <itunes:author>another basic item itunes author</itunes:author>
+            <itunes:duration>1:11:05</itunes:duration>
+            <itunes:explicit>clean</itunes:explicit>
+            <itunes:image href="http://poo.poo/gif.jpg"/>
+            <itunes:keywords/>
+            <itunes:order>1</itunes:order>
+            <itunes:subtitle>Another Subtitle</itunes:subtitle>
+            <itunes:summary>Another Summary</itunes:summary>
+        </item>
+    <adori:interactive>yes</adori:interactive>
+    <ihr:interactive>yes</ihr:interactive>
+  </channel>
+</rss>

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -230,7 +230,7 @@ class TestBasicFeed(unittest.TestCase):
     def test_interactive(self):
         self.assertFalse(self.podcast.interactive)
 
-class TestBasicInteractiveFeed(unittest.TestCase):
+class TestIHRInteractiveFeed(unittest.TestCase):
 
     def setUp(self):
         test_dir = os.path.dirname(__file__)

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -227,6 +227,111 @@ class TestBasicFeed(unittest.TestCase):
     def test_time_published(self):
         self.assertTrue(isinstance(self.podcast.date_time, datetime.date))
 
+    def test_interactive(self):
+        self.assertFalse(self.podcast.interactive)
+
+class TestBasicInteractiveFeed(unittest.TestCase):
+
+    def setUp(self):
+        test_dir = os.path.dirname(__file__)
+        test_feeds_dir = os.path.join(test_dir, 'test_feeds')
+        basic_podcast_path = os.path.join(test_feeds_dir, 'ihr_interactive_podcast.rss')
+        basic_podcast_file = open(basic_podcast_path, "rb")
+        self.basic_podcast = basic_podcast_file.read()
+        self.podcast = Podcast.Podcast(self.basic_podcast)
+
+    def test_loding_of_basic_podcast(self):
+        self.assertIsNotNone(self.basic_podcast)
+
+    def test_dict(self):
+        feed_dict = self.podcast.to_dict()
+        self.assertTrue(type(feed_dict) is dict)
+
+    def test_copyright(self):
+        self.assertEqual(self.podcast.copyright, "basic copyright")
+
+    def test_description(self):
+        self.assertEqual(self.podcast.description, "basic description")
+
+    def test_image(self):
+        self.assertEqual(self.podcast.image_url, "https://test/giffy.jpg")
+
+    def test_itunes_author_name(self):
+        self.assertEqual(self.podcast.itunes_author_name,
+                         "basic itunes author")
+
+    def test_itunes_block(self):
+        self.assertEqual(self.podcast.itunes_block, False)
+
+    def test_itunes_categories(self):
+        self.assertTrue("News" in self.podcast.itunes_categories)
+        self.assertTrue("Business News" in self.podcast.itunes_categories)
+        self.assertTrue("Health" in self.podcast.itunes_categories)
+
+    def test_itunes_explicit(self):
+        self.assertEqual(self.podcast.itunes_explicit, "clean")
+
+    def test_itunes_complete(self):
+        self.assertEqual(self.podcast.itunes_complete, "yes")
+
+    def test_itunes_image(self):
+        self.assertEqual(self.podcast.itunes_image,
+                         "https://github.com/iheartradio/pyPodcastParser.jpg")
+
+    def test_itunes_categories_length(self):
+        number_of_categories = len(self.podcast.itunes_categories)
+        self.assertEqual(number_of_categories, 3)
+
+    def test_itunes_keywords(self):
+        self.assertTrue("Python" in self.podcast.itunes_keywords)
+        self.assertTrue("Testing" in self.podcast.itunes_keywords)
+
+    def test_itunes_keyword_length(self):
+        number_of_keywords = len(self.podcast.itunes_keywords)
+        self.assertEqual(number_of_keywords, 2)
+
+    def test_itunes_new_feed_url(self):
+        self.assertEqual(self.podcast.itunes_new_feed_url, "http://newlocation.com/example.rss")
+
+    def test_language(self):
+        self.assertEqual(self.podcast.language, "basic  language")
+
+    def test_last_build_date(self):
+        self.assertEqual(self.podcast.last_build_date,
+                         "Mon, 24 Mar 2008 23:30:07 GMT")
+
+    def test_link(self):
+        self.assertEqual(self.podcast.link,
+                         "https://github.com/iheartradio/pyPodcastParser")
+
+    def test_published_date(self):
+        self.assertEqual(self.podcast.published_date,
+                         "Mon, 24 Mar 2008 23:30:07 GMT")
+
+    def test_owner_name(self):
+        self.assertEqual(self.podcast.owner_name, "basic itunes owner name")
+
+    def test_owner_email(self):
+        self.assertEqual(self.podcast.owner_email, "basic itunes owner email")
+
+    def test_subtitle(self):
+        self.assertEqual(self.podcast.subtitle, "basic itunes subtitle")
+
+    def test_summary(self):
+        self.assertEqual(self.podcast.summary, "basic itunes summary")
+
+    def test_summary(self):
+        self.assertEqual(self.podcast.summary, "basic itunes summary")
+
+    def test_title(self):
+        self.assertEqual(self.podcast.title, "basic title")
+
+    def test_time_published(self):
+        self.assertTrue(isinstance(self.podcast.date_time, datetime.date))
+
+    def test_interactive(self):
+        self.assertTrue(self.podcast.interactive)
+
 
 class TestKeywordVariability(unittest.TestCase):
     def setUp(self):
@@ -408,6 +513,9 @@ class TestMissingInfoFeed(unittest.TestCase):
 
     def test_time_published(self):
         self.assertIsNone(self.podcast.date_time)
+    
+    def test_interactive(self):
+        self.assertFalse(self.podcast.interactive)
 
 
 class TestItunesBlockFeed(unittest.TestCase):


### PR DESCRIPTION
## JIRA Ticket
- https://ihm-it.atlassian.net/browse/IHRACP-3926

## Description
- Parse ihr:interactive tags from xml files.

#### Major Changes:
- Include logic in Podcast to pull ihr:interactive tags from xml.  Add unit test to cover pulling in interactive tags.

## How To Test

1. Run unit tests, new test TestIHRInteractiveFeed checks to see if interactive tag is properly set when parsing rss feeds.
