### PR TITLE
Feature/episode vids

### DIFF
--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -660,7 +660,7 @@ class Item(object):
             enclosure_dict = {}
 
             # Parse main alternateEnclosure attributes
-            enclosure_dict["type"] = tag.get("type", None)
+            enclosure_dict["mime_type"] = tag.get("type", None)
             enclosure_dict["length"] = tag.get("length", None)
             if enclosure_dict["length"]:
                 try:
@@ -688,11 +688,11 @@ class Item(object):
             enclosure_dict["codecs"] = tag.get("codecs", None)
 
             # Parse default attribute as boolean
-            default_value = tag.get("default", None)
+            default_value = tag.get("default", False)
             if default_value:
-                enclosure_dict["default"] = default_value.lower() in ["true", "1", "yes"]
+                enclosure_dict["default"] = True
             else:
-                enclosure_dict["default"] = None
+                enclosure_dict["default"] = False
 
             # Parse nested podcast:source elements
             sources = []
@@ -701,8 +701,21 @@ class Item(object):
                     source_dict = {}
                     # Support both 'uri' (spec) and 'url' (some feeds use this)
                     source_dict["uri"] = source_tag.get("uri", None) or source_tag.get("url", None)
-                    source_dict["contentType"] = source_tag.get("contentType", None)
+                    source_dict["content_type"] = source_tag.get("contentType", None)
+                    source_dict["integrity_type"] = None
+                    source_dict["integrity_value"] = None
+                    
                     sources.append(source_dict)
+
+            # Parse podcast:integrity elements and add to all sources (applies to the content itself)
+            for integrity_tag in tag.find_all("integrity", recursive=False):
+                if (integrity_tag.prefix == "podcast" or not integrity_tag.prefix) and len(sources) > 0:
+                    integrity_type = integrity_tag.get("type", None)
+                    integrity_value = integrity_tag.get("value", None)
+                    # Add integrity to all sources since it applies to the media content
+                    for source in sources:
+                        source["integrity_type"] = integrity_type
+                        source["integrity_value"] = integrity_value
 
             enclosure_dict["sources"] = sources
 

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -691,11 +691,9 @@ class Item(object):
             enclosure_dict["codecs"] = tag.get("codecs", None)
 
             # Parse default attribute as boolean
-            default_value = tag.get("default", False)
-            if default_value:
-                enclosure_dict["default"] = True
-            else:
-                enclosure_dict["default"] = False
+            default_value = tag.get("default", "False")
+            falsy_strings = ("false", "0", "no", "False")
+            enclosure_dict["default"] = default_value.lower() not in falsy_strings
 
             # Parse nested podcast:source elements
             sources = []

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -170,6 +170,7 @@ class Item(object):
         self.is_interactive = None
         self.podcast_transcript = None
         self.transcriptionList = []
+        self.alternate_enclosures = []
 
         tag_methods = {
             (None, "title"): self.set_title,
@@ -193,6 +194,7 @@ class Item(object):
             ("itunes", "subtitle"): self.set_itunes_subtitle,
             ("itunes", "summary"): self.set_itunes_summary,
             ("ihr", "interactive"): self.set_interactive,
+            ("podcast", "alternateEnclosure"): self.set_alternate_enclosure,
         }
 
         # Populate attributes based on feed content
@@ -201,7 +203,7 @@ class Item(object):
                 continue
             try:
                 # Using get instead of pop since there can be multiple transcript tags (meaning we don't want to get rid of method after use)
-                if c.name == "transcript":
+                if c.name == "transcript" or c.name == "alternateEnclosure":
                     tag_method = tag_methods.get((c.prefix, c.name))
                 else:
                     # Pop method to skip duplicated tag on invalid feeds
@@ -258,6 +260,7 @@ class Item(object):
         item["interactive"] = self.interactive
         item["external_url"] = self.enclosure_url
         item["transcription"] = self.podcast_transcript
+        item["alternate_enclosures"] = self.alternate_enclosures
 
         return item
 
@@ -645,4 +648,69 @@ class Item(object):
         except Exception:
             raise InvalidPodcastFeed(
                 f"Invalid Podcast Feed, episode level ihr:interactive: {tag.string}, could not be parsed"
+            )
+
+    def set_alternate_enclosure(self, tag):
+        """Parses podcast:alternateEnclosure and its nested podcast:source elements.
+        
+        The alternateEnclosure element provides alternative media versions with different
+        formats, quality levels, and transport methods (HTTPS, IPFS, torrents, etc.).
+        """
+        try:
+            enclosure_dict = {}
+            
+            # Parse main alternateEnclosure attributes
+            enclosure_dict["type"] = tag.get("type", None)
+            enclosure_dict["length"] = tag.get("length", None)
+            if enclosure_dict["length"]:
+                try:
+                    enclosure_dict["length"] = int(enclosure_dict["length"])
+                except (ValueError, TypeError):
+                    pass
+            
+            enclosure_dict["bitrate"] = tag.get("bitrate", None)
+            if enclosure_dict["bitrate"]:
+                try:
+                    enclosure_dict["bitrate"] = float(enclosure_dict["bitrate"])
+                except (ValueError, TypeError):
+                    pass
+            
+            enclosure_dict["height"] = tag.get("height", None)
+            if enclosure_dict["height"]:
+                try:
+                    enclosure_dict["height"] = int(enclosure_dict["height"])
+                except (ValueError, TypeError):
+                    pass
+            
+            enclosure_dict["lang"] = tag.get("lang", None)
+            enclosure_dict["title"] = tag.get("title", None)
+            enclosure_dict["rel"] = tag.get("rel", None)
+            enclosure_dict["codecs"] = tag.get("codecs", None)
+            
+            # Parse default attribute as boolean
+            default_value = tag.get("default", None)
+            if default_value:
+                enclosure_dict["default"] = default_value.lower() in ["true", "1", "yes"]
+            else:
+                enclosure_dict["default"] = None
+            
+            # Parse nested podcast:source elements
+            sources = []
+            for source_tag in tag.find_all("source", recursive=False):
+                if source_tag.prefix == "podcast" or not source_tag.prefix:
+                    source_dict = {}
+                    source_dict["uri"] = source_tag.get("uri", None)
+                    source_dict["contentType"] = source_tag.get("contentType", None)
+                    sources.append(source_dict)
+            
+            enclosure_dict["sources"] = sources
+            
+            self.alternate_enclosures.append(enclosure_dict)
+            
+        except AttributeError:
+            # If there's an issue parsing, we don't add it to the list
+            pass
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level podcast:alternateEnclosure could not be parsed"
             )

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -259,11 +259,8 @@ class Item(object):
         item["episode_title"] = self.title
         item["interactive"] = self.interactive
         item["external_url"] = self.enclosure_url
-        item["enclosure"] = {
-            "url": self.enclosure_url,
-            "enclosure_length": self.enclosure_length,
-            "enclosure_type": self.enclosure_type
-        }
+        item["enclosure_type"] = self.enclosure_type
+        item["enclosure_length"] = self.enclosure_length
         item["transcription"] = self.podcast_transcript
         item["alternate_enclosures"] = self.alternate_enclosures
 

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -704,7 +704,6 @@ class Item(object):
                     source_dict["content_type"] = source_tag.get("contentType", None)
                     source_dict["integrity_type"] = None
                     source_dict["integrity_value"] = None
-                    
                     sources.append(source_dict)
 
             # Parse podcast:integrity elements and add to all sources (applies to the content itself)

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -264,7 +264,6 @@ class Item(object):
         item["transcription"] = self.podcast_transcript
         item["alternate_enclosures"] = self.alternate_enclosures
 
-
         return item
 
     def set_rss_element(self):

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -652,13 +652,13 @@ class Item(object):
 
     def set_alternate_enclosure(self, tag):
         """Parses podcast:alternateEnclosure and its nested podcast:source elements.
-        
+
         The alternateEnclosure element provides alternative media versions with different
         formats, quality levels, and transport methods (HTTPS, IPFS, torrents, etc.).
         """
         try:
             enclosure_dict = {}
-            
+
             # Parse main alternateEnclosure attributes
             enclosure_dict["type"] = tag.get("type", None)
             enclosure_dict["length"] = tag.get("length", None)
@@ -667,33 +667,33 @@ class Item(object):
                     enclosure_dict["length"] = int(enclosure_dict["length"])
                 except (ValueError, TypeError):
                     pass
-            
+
             enclosure_dict["bitrate"] = tag.get("bitrate", None)
             if enclosure_dict["bitrate"]:
                 try:
                     enclosure_dict["bitrate"] = float(enclosure_dict["bitrate"])
                 except (ValueError, TypeError):
                     pass
-            
+
             enclosure_dict["height"] = tag.get("height", None)
             if enclosure_dict["height"]:
                 try:
                     enclosure_dict["height"] = int(enclosure_dict["height"])
                 except (ValueError, TypeError):
                     pass
-            
+
             enclosure_dict["lang"] = tag.get("lang", None)
             enclosure_dict["title"] = tag.get("title", None)
             enclosure_dict["rel"] = tag.get("rel", None)
             enclosure_dict["codecs"] = tag.get("codecs", None)
-            
+
             # Parse default attribute as boolean
             default_value = tag.get("default", None)
             if default_value:
                 enclosure_dict["default"] = default_value.lower() in ["true", "1", "yes"]
             else:
                 enclosure_dict["default"] = None
-            
+
             # Parse nested podcast:source elements
             sources = []
             for source_tag in tag.find_all("source", recursive=False):
@@ -702,11 +702,11 @@ class Item(object):
                     source_dict["uri"] = source_tag.get("uri", None)
                     source_dict["contentType"] = source_tag.get("contentType", None)
                     sources.append(source_dict)
-            
+
             enclosure_dict["sources"] = sources
-            
+
             self.alternate_enclosures.append(enclosure_dict)
-            
+
         except AttributeError:
             # If there's an issue parsing, we don't add it to the list
             pass

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -262,7 +262,7 @@ class Item(object):
         item["enclosure"] = {
             "url": self.enclosure_url,
             "enclosure_length": self.enclosure_length,
-            "mime_type": self.enclosure_type
+            "enclosure_type": self.enclosure_type
         }
         item["transcription"] = self.podcast_transcript
         item["alternate_enclosures"] = self.alternate_enclosures

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -699,7 +699,8 @@ class Item(object):
             for source_tag in tag.find_all("source", recursive=False):
                 if source_tag.prefix == "podcast" or not source_tag.prefix:
                     source_dict = {}
-                    source_dict["url"] = source_tag.get("url", None)
+                    # Support both 'uri' (spec) and 'url' (some feeds use this)
+                    source_dict["uri"] = source_tag.get("uri", None) or source_tag.get("url", None)
                     source_dict["contentType"] = source_tag.get("contentType", None)
                     sources.append(source_dict)
 

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -699,7 +699,7 @@ class Item(object):
             for source_tag in tag.find_all("source", recursive=False):
                 if source_tag.prefix == "podcast" or not source_tag.prefix:
                     source_dict = {}
-                    source_dict["uri"] = source_tag.get("uri", None)
+                    source_dict["url"] = source_tag.get("url", None)
                     source_dict["contentType"] = source_tag.get("contentType", None)
                     sources.append(source_dict)
 

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -259,6 +259,11 @@ class Item(object):
         item["episode_title"] = self.title
         item["interactive"] = self.interactive
         item["external_url"] = self.enclosure_url
+        item["enclosure"] = {
+            "url": self.enclosure_url,
+            "enclosure_length": self.enclosure_length,
+            "mime_type": self.enclosure_type
+        }
         item["transcription"] = self.podcast_transcript
         item["alternate_enclosures"] = self.alternate_enclosures
 

--- a/pypodcastparser/Item.py
+++ b/pypodcastparser/Item.py
@@ -264,6 +264,7 @@ class Item(object):
         item["transcription"] = self.podcast_transcript
         item["alternate_enclosures"] = self.alternate_enclosures
 
+
         return item
 
     def set_rss_element(self):

--- a/tests/test_feeds/alternate_enclosure.rss
+++ b/tests/test_feeds/alternate_enclosure.rss
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" 
+     xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+     xmlns:podcast="https://podcastindex.org/namespace/1.0">
+    <channel>
+        <title>Alternate Enclosure Test Podcast</title>
+        <description>Test podcast for alternateEnclosure parsing</description>
+        <link>https://example.com</link>
+        <language>en-us</language>
+        <itunes:author>Test Author</itunes:author>
+        <itunes:explicit>no</itunes:explicit>
+        
+        <item>
+            <title>Episode with Multiple Alternate Enclosures</title>
+            <description>This episode has multiple media versions</description>
+            <pubDate>Tue, 07 Jan 2025 10:00:00 EST</pubDate>
+            <guid>episode-001</guid>
+            
+            <!-- Standard enclosure (required for backward compatibility) -->
+            <enclosure url="https://example.com/episode001.mp3" length="43200000" type="audio/mpeg" />
+            
+            <!-- Same content via multiple transports -->
+            <podcast:alternateEnclosure 
+                type="audio/mpeg" 
+                length="43200000" 
+                bitrate="128000" 
+                default="true" 
+                title="Standard MP3">
+                <podcast:source uri="https://example.com/episode001.mp3" />
+                <podcast:source uri="ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y" />
+                <podcast:source uri="https://example.com/episode001.torrent" contentType="application/x-bittorrent" />
+            </podcast:alternateEnclosure>
+            
+            <!-- High quality Opus version -->
+            <podcast:alternateEnclosure 
+                type="audio/opus" 
+                length="32400000" 
+                bitrate="96000" 
+                title="High Quality Opus">
+                <podcast:source uri="https://example.com/episode001.opus" />
+                <podcast:source uri="ipfs://QmHighQualityOpusFile123456789" />
+            </podcast:alternateEnclosure>
+            
+            <!-- Video version at 1080p -->
+            <podcast:alternateEnclosure 
+                type="video/mp4" 
+                length="10562995" 
+                bitrate="681483.55" 
+                height="1080"
+                codecs="avc1.64001f, mp4a.40.2"
+                lang="en">
+                <podcast:source uri="https://example.com/episode001-1080.mp4" />
+                <podcast:source uri="ipfs://QmVideoFile1080pHashHere" />
+                <podcast:source uri="http://example.onion/episode001-1080.mp4" />
+            </podcast:alternateEnclosure>
+            
+            <!-- HLS streaming version -->
+            <podcast:alternateEnclosure 
+                type="application/x-mpegURL" 
+                length="10562995"
+                title="HLS Stream">
+                <podcast:source uri="https://example.com/episode001/master.m3u8" />
+            </podcast:alternateEnclosure>
+            
+            <itunes:duration>45:00</itunes:duration>
+            <itunes:explicit>no</itunes:explicit>
+        </item>
+        
+        <item>
+            <title>Episode with Behind the Scenes Content</title>
+            <description>This episode has main content plus bonus material</description>
+            <pubDate>Mon, 06 Jan 2025 10:00:00 EST</pubDate>
+            <guid>episode-002</guid>
+            
+            <!-- Standard enclosure -->
+            <enclosure url="https://example.com/episode002.mp3" length="36000000" type="audio/mpeg" />
+            
+            <!-- Main episode content -->
+            <podcast:alternateEnclosure 
+                type="audio/mpeg" 
+                length="36000000" 
+                bitrate="128000" 
+                default="true">
+                <podcast:source uri="https://example.com/episode002.mp3" />
+            </podcast:alternateEnclosure>
+            
+            <!-- Behind the scenes bonus content (different rel) -->
+            <podcast:alternateEnclosure 
+                type="audio/mpeg" 
+                length="12000000" 
+                bitrate="128000"
+                title="Behind the Scenes" 
+                rel="bonus">
+                <podcast:source uri="https://example.com/episode002-bts.mp3" />
+            </podcast:alternateEnclosure>
+            
+            <itunes:duration>37:30</itunes:duration>
+            <itunes:explicit>no</itunes:explicit>
+        </item>
+        
+        <item>
+            <title>Episode with No Alternate Enclosures</title>
+            <description>This episode only has standard enclosure</description>
+            <pubDate>Sun, 05 Jan 2025 10:00:00 EST</pubDate>
+            <guid>episode-003</guid>
+            
+            <!-- Only standard enclosure, no alternateEnclosure -->
+            <enclosure url="https://example.com/episode003.mp3" length="28800000" type="audio/mpeg" />
+            
+            <itunes:duration>30:00</itunes:duration>
+            <itunes:explicit>no</itunes:explicit>
+        </item>
+    </channel>
+</rss>

--- a/tests/test_feeds/alternate_enclosure.rss
+++ b/tests/test_feeds/alternate_enclosure.rss
@@ -29,6 +29,7 @@
                 <podcast:source uri="https://example.com/episode001.mp3" />
                 <podcast:source uri="ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y" />
                 <podcast:source uri="https://example.com/episode001.torrent" contentType="application/x-bittorrent" />
+                <podcast:integrity type="sri" value="sha384-ExVqijpSE+cRZuKN5LoVBBsPA6dyjmRH5cXjqfiDD8fmtXi3pdb+qOiFvQdkWh1R" />
             </podcast:alternateEnclosure>
             
             <!-- High quality Opus version -->

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -797,6 +797,22 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertIn("alternate_enclosures", item_dict)
         self.assertEqual(len(item_dict["alternate_enclosures"]), 4)
 
+    def test_to_dict_includes_enclosure_object(self):
+        """Test that to_dict() includes enclosure object with length and mime_type"""
+        item = self.podcast.items[0]
+        item_dict = item.to_dict()
+        
+        self.assertIn("enclosure", item_dict)
+        self.assertIsInstance(item_dict["enclosure"], dict)
+        self.assertIn("url", item_dict["enclosure"])
+        self.assertIn("enclosure_length", item_dict["enclosure"])
+        self.assertIn("mime_type", item_dict["enclosure"])
+        
+        # Verify the values match the item attributes
+        self.assertEqual(item_dict["enclosure"]["url"], item.enclosure_url)
+        self.assertEqual(item_dict["enclosure"]["enclosure_length"], item.enclosure_length)
+        self.assertEqual(item_dict["enclosure"]["mime_type"], item.enclosure_type)
+
     def test_optional_attributes_can_be_none(self):
         """Test that optional attributes are None when not present"""
         item = self.podcast.items[0]

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -797,21 +797,17 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertIn("alternate_enclosures", item_dict)
         self.assertEqual(len(item_dict["alternate_enclosures"]), 4)
 
-    def test_to_dict_includes_enclosure_object(self):
-        """Test that to_dict() includes enclosure object with length and mime_type"""
+    def test_to_dict_includes_enclosure_fields(self):
+        """Test that to_dict() includes enclosure_length and enclosure_type fields"""
         item = self.podcast.items[0]
         item_dict = item.to_dict()
         
-        self.assertIn("enclosure", item_dict)
-        self.assertIsInstance(item_dict["enclosure"], dict)
-        self.assertIn("url", item_dict["enclosure"])
-        self.assertIn("enclosure_length", item_dict["enclosure"])
-        self.assertIn("enclosure_type", item_dict["enclosure"])
+        self.assertIn("enclosure_length", item_dict)
+        self.assertIn("enclosure_type", item_dict)
         
         # Verify the values match the item attributes
-        self.assertEqual(item_dict["enclosure"]["url"], item.enclosure_url)
-        self.assertEqual(item_dict["enclosure"]["enclosure_length"], item.enclosure_length)
-        self.assertEqual(item_dict["enclosure"]["enclosure_type"], item.enclosure_type)
+        self.assertEqual(item_dict["enclosure_length"], item.enclosure_length)
+        self.assertEqual(item_dict["enclosure_type"], item.enclosure_type)
 
     def test_optional_attributes_can_be_none(self):
         """Test that optional attributes are None when not present"""

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -797,18 +797,6 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertIn("alternate_enclosures", item_dict)
         self.assertEqual(len(item_dict["alternate_enclosures"]), 4)
 
-    def test_to_dict_includes_enclosure_fields(self):
-        """Test that to_dict() includes enclosure_length and enclosure_type fields"""
-        item = self.podcast.items[0]
-        item_dict = item.to_dict()
-        
-        self.assertIn("enclosure_length", item_dict)
-        self.assertIn("enclosure_type", item_dict)
-        
-        # Verify the values match the item attributes
-        self.assertEqual(item_dict["enclosure_length"], item.enclosure_length)
-        self.assertEqual(item_dict["enclosure_type"], item.enclosure_type)
-
     def test_optional_attributes_can_be_none(self):
         """Test that optional attributes are None when not present"""
         item = self.podcast.items[0]

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -806,12 +806,12 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertIsInstance(item_dict["enclosure"], dict)
         self.assertIn("url", item_dict["enclosure"])
         self.assertIn("enclosure_length", item_dict["enclosure"])
-        self.assertIn("mime_type", item_dict["enclosure"])
+        self.assertIn("enclosure_type", item_dict["enclosure"])
         
         # Verify the values match the item attributes
         self.assertEqual(item_dict["enclosure"]["url"], item.enclosure_url)
         self.assertEqual(item_dict["enclosure"]["enclosure_length"], item.enclosure_length)
-        self.assertEqual(item_dict["enclosure"]["mime_type"], item.enclosure_type)
+        self.assertEqual(item_dict["enclosure"]["enclosure_type"], item.enclosure_type)
 
     def test_optional_attributes_can_be_none(self):
         """Test that optional attributes are None when not present"""

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -699,14 +699,14 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertEqual(len(mp3_enclosure["sources"]), 3)
         
         # Check HTTPS source
-        self.assertEqual(mp3_enclosure["sources"][0]["url"], "https://example.com/episode001.mp3")
+        self.assertEqual(mp3_enclosure["sources"][0]["uri"], "https://example.com/episode001.mp3")
         self.assertIsNone(mp3_enclosure["sources"][0]["contentType"])
         
         # Check IPFS source
-        self.assertEqual(mp3_enclosure["sources"][1]["url"], "ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y")
+        self.assertEqual(mp3_enclosure["sources"][1]["uri"], "ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y")
         
         # Check torrent source
-        self.assertEqual(mp3_enclosure["sources"][2]["url"], "https://example.com/episode001.torrent")
+        self.assertEqual(mp3_enclosure["sources"][2]["uri"], "https://example.com/episode001.torrent")
         self.assertEqual(mp3_enclosure["sources"][2]["contentType"], "application/x-bittorrent")
 
     def test_opus_alternate_enclosure(self):
@@ -734,7 +734,7 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertEqual(len(video_enclosure["sources"]), 3)
         
         # Check Tor source
-        self.assertIn("example.onion", video_enclosure["sources"][2]["url"])
+        self.assertIn("example.onion", video_enclosure["sources"][2]["uri"])
 
     def test_hls_alternate_enclosure(self):
         """Test HLS streaming alternate enclosure"""
@@ -744,7 +744,7 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertEqual(hls_enclosure["type"], "application/x-mpegURL")
         self.assertEqual(hls_enclosure["title"], "HLS Stream")
         self.assertEqual(len(hls_enclosure["sources"]), 1)
-        self.assertIn("master.m3u8", hls_enclosure["sources"][0]["url"])
+        self.assertIn("master.m3u8", hls_enclosure["sources"][0]["uri"])
 
     def test_second_item_with_rel_attribute(self):
         """Test second item with bonus content (different rel)"""

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -699,14 +699,14 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertEqual(len(mp3_enclosure["sources"]), 3)
         
         # Check HTTPS source
-        self.assertEqual(mp3_enclosure["sources"][0]["uri"], "https://example.com/episode001.mp3")
+        self.assertEqual(mp3_enclosure["sources"][0]["url"], "https://example.com/episode001.mp3")
         self.assertIsNone(mp3_enclosure["sources"][0]["contentType"])
         
         # Check IPFS source
-        self.assertEqual(mp3_enclosure["sources"][1]["uri"], "ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y")
+        self.assertEqual(mp3_enclosure["sources"][1]["url"], "ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y")
         
         # Check torrent source
-        self.assertEqual(mp3_enclosure["sources"][2]["uri"], "https://example.com/episode001.torrent")
+        self.assertEqual(mp3_enclosure["sources"][2]["url"], "https://example.com/episode001.torrent")
         self.assertEqual(mp3_enclosure["sources"][2]["contentType"], "application/x-bittorrent")
 
     def test_opus_alternate_enclosure(self):
@@ -734,7 +734,7 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertEqual(len(video_enclosure["sources"]), 3)
         
         # Check Tor source
-        self.assertIn("example.onion", video_enclosure["sources"][2]["uri"])
+        self.assertIn("example.onion", video_enclosure["sources"][2]["url"])
 
     def test_hls_alternate_enclosure(self):
         """Test HLS streaming alternate enclosure"""
@@ -744,7 +744,7 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         self.assertEqual(hls_enclosure["type"], "application/x-mpegURL")
         self.assertEqual(hls_enclosure["title"], "HLS Stream")
         self.assertEqual(len(hls_enclosure["sources"]), 1)
-        self.assertIn("master.m3u8", hls_enclosure["sources"][0]["uri"])
+        self.assertIn("master.m3u8", hls_enclosure["sources"][0]["url"])
 
     def test_second_item_with_rel_attribute(self):
         """Test second item with bonus content (different rel)"""

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -685,7 +685,7 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         item = self.podcast.items[0]
         mp3_enclosure = item.alternate_enclosures[0]
         
-        self.assertEqual(mp3_enclosure["type"], "audio/mpeg")
+        self.assertEqual(mp3_enclosure["mime_type"], "audio/mpeg")
         self.assertEqual(mp3_enclosure["length"], 43200000)
         self.assertEqual(mp3_enclosure["bitrate"], 128000.0)
         self.assertEqual(mp3_enclosure["default"], True)
@@ -698,23 +698,41 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         
         self.assertEqual(len(mp3_enclosure["sources"]), 3)
         
-        # Check HTTPS source
+        # Check HTTPS source - all sources should have the same integrity
         self.assertEqual(mp3_enclosure["sources"][0]["uri"], "https://example.com/episode001.mp3")
-        self.assertIsNone(mp3_enclosure["sources"][0]["contentType"])
+        self.assertIsNone(mp3_enclosure["sources"][0]["content_type"])
+        self.assertEqual(mp3_enclosure["sources"][0]["integrity_type"], "sri")
+        self.assertEqual(mp3_enclosure["sources"][0]["integrity_value"], "sha384-ExVqijpSE+cRZuKN5LoVBBsPA6dyjmRH5cXjqfiDD8fmtXi3pdb+qOiFvQdkWh1R")
         
-        # Check IPFS source
+        # Check IPFS source - should also have integrity
         self.assertEqual(mp3_enclosure["sources"][1]["uri"], "ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y")
+        self.assertEqual(mp3_enclosure["sources"][1]["integrity_type"], "sri")
+        self.assertEqual(mp3_enclosure["sources"][1]["integrity_value"], "sha384-ExVqijpSE+cRZuKN5LoVBBsPA6dyjmRH5cXjqfiDD8fmtXi3pdb+qOiFvQdkWh1R")
         
-        # Check torrent source
+        # Check torrent source - should also have integrity
         self.assertEqual(mp3_enclosure["sources"][2]["uri"], "https://example.com/episode001.torrent")
-        self.assertEqual(mp3_enclosure["sources"][2]["contentType"], "application/x-bittorrent")
+        self.assertEqual(mp3_enclosure["sources"][2]["content_type"], "application/x-bittorrent")
+        self.assertEqual(mp3_enclosure["sources"][2]["integrity_type"], "sri")
+        self.assertEqual(mp3_enclosure["sources"][2]["integrity_value"], "sha384-ExVqijpSE+cRZuKN5LoVBBsPA6dyjmRH5cXjqfiDD8fmtXi3pdb+qOiFvQdkWh1R")
+
+    def test_mp3_alternate_enclosure_integrity(self):
+        """Test MP3 alternate enclosure has integrity in all sources"""
+        item = self.podcast.items[0]
+        mp3_enclosure = item.alternate_enclosures[0]
+        
+        # Check that all sources have the same integrity values
+        for source in mp3_enclosure["sources"]:
+            self.assertIsNotNone(source["integrity_type"])
+            self.assertIsNotNone(source["integrity_value"])
+            self.assertEqual(source["integrity_type"], "sri")
+            self.assertEqual(source["integrity_value"], "sha384-ExVqijpSE+cRZuKN5LoVBBsPA6dyjmRH5cXjqfiDD8fmtXi3pdb+qOiFvQdkWh1R")
 
     def test_opus_alternate_enclosure(self):
         """Test Opus alternate enclosure parsing"""
         item = self.podcast.items[0]
         opus_enclosure = item.alternate_enclosures[1]
         
-        self.assertEqual(opus_enclosure["type"], "audio/opus")
+        self.assertEqual(opus_enclosure["mime_type"], "audio/opus")
         self.assertEqual(opus_enclosure["length"], 32400000)
         self.assertEqual(opus_enclosure["bitrate"], 96000.0)
         self.assertEqual(opus_enclosure["title"], "High Quality Opus")
@@ -725,7 +743,7 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         item = self.podcast.items[0]
         video_enclosure = item.alternate_enclosures[2]
         
-        self.assertEqual(video_enclosure["type"], "video/mp4")
+        self.assertEqual(video_enclosure["mime_type"], "video/mp4")
         self.assertEqual(video_enclosure["length"], 10562995)
         self.assertEqual(video_enclosure["bitrate"], 681483.55)
         self.assertEqual(video_enclosure["height"], 1080)
@@ -741,7 +759,7 @@ class TestAlternateEnclosureFeed(unittest.TestCase):
         item = self.podcast.items[0]
         hls_enclosure = item.alternate_enclosures[3]
         
-        self.assertEqual(hls_enclosure["type"], "application/x-mpegURL")
+        self.assertEqual(hls_enclosure["mime_type"], "application/x-mpegURL")
         self.assertEqual(hls_enclosure["title"], "HLS Stream")
         self.assertEqual(len(hls_enclosure["sources"]), 1)
         self.assertIn("master.m3u8", hls_enclosure["sources"][0]["uri"])

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -654,5 +654,142 @@ class TestInvalidEpisodeDates(unittest.TestCase):
         )
 
 
+class TestAlternateEnclosureFeed(unittest.TestCase):
+    def setUp(self):
+        test_dir = os.path.dirname(__file__)
+        test_feeds_dir = os.path.join(test_dir, "test_feeds")
+        alt_enclosure_path = os.path.join(test_feeds_dir, "alternate_enclosure.rss")
+        alt_enclosure_file = open(alt_enclosure_path, "rb")
+        self.alt_enclosure_feed = alt_enclosure_file.read()
+        self.podcast = Podcast.Podcast(self.alt_enclosure_feed)
+
+    def test_item_count(self):
+        """Test that all three items are parsed"""
+        self.assertEqual(len(self.podcast.items), 3)
+
+    def test_first_item_has_alternate_enclosures(self):
+        """Test that first item has multiple alternate enclosures"""
+        item = self.podcast.items[0]
+        self.assertIsNotNone(item.alternate_enclosures)
+        self.assertEqual(len(item.alternate_enclosures), 4)
+
+    def test_standard_enclosure_still_works(self):
+        """Test that standard enclosure attributes are still parsed"""
+        item = self.podcast.items[0]
+        self.assertEqual(item.enclosure_url, "https://example.com/episode001.mp3")
+        self.assertEqual(item.enclosure_type, "audio/mpeg")
+        self.assertEqual(item.enclosure_length, 43200000)
+
+    def test_mp3_alternate_enclosure_attributes(self):
+        """Test MP3 alternate enclosure with default=true"""
+        item = self.podcast.items[0]
+        mp3_enclosure = item.alternate_enclosures[0]
+        
+        self.assertEqual(mp3_enclosure["type"], "audio/mpeg")
+        self.assertEqual(mp3_enclosure["length"], 43200000)
+        self.assertEqual(mp3_enclosure["bitrate"], 128000.0)
+        self.assertEqual(mp3_enclosure["default"], True)
+        self.assertEqual(mp3_enclosure["title"], "Standard MP3")
+
+    def test_mp3_alternate_enclosure_sources(self):
+        """Test MP3 alternate enclosure has multiple sources"""
+        item = self.podcast.items[0]
+        mp3_enclosure = item.alternate_enclosures[0]
+        
+        self.assertEqual(len(mp3_enclosure["sources"]), 3)
+        
+        # Check HTTPS source
+        self.assertEqual(mp3_enclosure["sources"][0]["uri"], "https://example.com/episode001.mp3")
+        self.assertIsNone(mp3_enclosure["sources"][0]["contentType"])
+        
+        # Check IPFS source
+        self.assertEqual(mp3_enclosure["sources"][1]["uri"], "ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y")
+        
+        # Check torrent source
+        self.assertEqual(mp3_enclosure["sources"][2]["uri"], "https://example.com/episode001.torrent")
+        self.assertEqual(mp3_enclosure["sources"][2]["contentType"], "application/x-bittorrent")
+
+    def test_opus_alternate_enclosure(self):
+        """Test Opus alternate enclosure parsing"""
+        item = self.podcast.items[0]
+        opus_enclosure = item.alternate_enclosures[1]
+        
+        self.assertEqual(opus_enclosure["type"], "audio/opus")
+        self.assertEqual(opus_enclosure["length"], 32400000)
+        self.assertEqual(opus_enclosure["bitrate"], 96000.0)
+        self.assertEqual(opus_enclosure["title"], "High Quality Opus")
+        self.assertEqual(len(opus_enclosure["sources"]), 2)
+
+    def test_video_alternate_enclosure(self):
+        """Test video alternate enclosure with height, codecs, and lang"""
+        item = self.podcast.items[0]
+        video_enclosure = item.alternate_enclosures[2]
+        
+        self.assertEqual(video_enclosure["type"], "video/mp4")
+        self.assertEqual(video_enclosure["length"], 10562995)
+        self.assertEqual(video_enclosure["bitrate"], 681483.55)
+        self.assertEqual(video_enclosure["height"], 1080)
+        self.assertEqual(video_enclosure["codecs"], "avc1.64001f, mp4a.40.2")
+        self.assertEqual(video_enclosure["lang"], "en")
+        self.assertEqual(len(video_enclosure["sources"]), 3)
+        
+        # Check Tor source
+        self.assertIn("example.onion", video_enclosure["sources"][2]["uri"])
+
+    def test_hls_alternate_enclosure(self):
+        """Test HLS streaming alternate enclosure"""
+        item = self.podcast.items[0]
+        hls_enclosure = item.alternate_enclosures[3]
+        
+        self.assertEqual(hls_enclosure["type"], "application/x-mpegURL")
+        self.assertEqual(hls_enclosure["title"], "HLS Stream")
+        self.assertEqual(len(hls_enclosure["sources"]), 1)
+        self.assertIn("master.m3u8", hls_enclosure["sources"][0]["uri"])
+
+    def test_second_item_with_rel_attribute(self):
+        """Test second item with bonus content (different rel)"""
+        item = self.podcast.items[1]
+        self.assertEqual(len(item.alternate_enclosures), 2)
+        
+        # Check main content
+        main_enclosure = item.alternate_enclosures[0]
+        self.assertEqual(main_enclosure["default"], True)
+        self.assertIsNone(main_enclosure["rel"])
+        
+        # Check bonus content
+        bonus_enclosure = item.alternate_enclosures[1]
+        self.assertEqual(bonus_enclosure["title"], "Behind the Scenes")
+        self.assertEqual(bonus_enclosure["rel"], "bonus")
+        self.assertEqual(bonus_enclosure["length"], 12000000)
+
+    def test_third_item_no_alternate_enclosures(self):
+        """Test third item has no alternate enclosures"""
+        item = self.podcast.items[2]
+        self.assertEqual(len(item.alternate_enclosures), 0)
+        
+        # But standard enclosure should still work
+        self.assertEqual(item.enclosure_url, "https://example.com/episode003.mp3")
+        self.assertEqual(item.enclosure_length, 28800000)
+
+    def test_to_dict_includes_alternate_enclosures(self):
+        """Test that to_dict() includes alternate_enclosures"""
+        item = self.podcast.items[0]
+        item_dict = item.to_dict()
+        
+        self.assertIn("alternate_enclosures", item_dict)
+        self.assertEqual(len(item_dict["alternate_enclosures"]), 4)
+
+    def test_optional_attributes_can_be_none(self):
+        """Test that optional attributes are None when not present"""
+        item = self.podcast.items[0]
+        mp3_enclosure = item.alternate_enclosures[0]
+        
+        # These attributes weren't specified for MP3 enclosure
+        self.assertIsNone(mp3_enclosure["height"])
+        self.assertIsNone(mp3_enclosure["lang"])
+        self.assertIsNone(mp3_enclosure["codecs"])
+        self.assertIsNone(mp3_enclosure["rel"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Jira Ticket 
- [Title](Url)


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Intended Behavior
Adds support for parsing `podcast:alternateEnclosure` elements from the Podcast Namespace specification (https://podcastindex.org/namespace/1.0). This allows podcast episodes to offer multiple media versions with different formats (MP3, Opus, AAC, video), quality levels, and transport methods (HTTPS, IPFS, torrents, HLS streaming).

## Describe Changes Made 
- Added `alternate_enclosures` list attribute to `Item` class to store parsed alternate enclosure data
- Implemented `set_alternate_enclosure()` method to parse all alternateEnclosure attributes including:
  - Required: `type` (MIME type)
  - Optional: `length`, `bitrate`, `height`, `lang`, `title`, `rel`, `codecs`, `default`
  - Nested `podcast:source` elements with `uri` and `contentType` attributes
- Registered alternateEnclosure parser in `tag_methods` dictionary with support for multiple enclosures per item
- Updated `Item.to_dict()` to include `alternate_enclosures` in serialized output
- Maintained backward compatibility with existing `enclosure_url`, `enclosure_type`, and `enclosure_length` attributes
- Created comprehensive test RSS feed with multiple alternateEnclosure scenarios
- Added 14 unit tests covering all attributes, multiple sources, video content, and edge cases

## System Performance Impact
Minimal impact. The parser only processes alternateEnclosure elements when present in the feed. For feeds without alternateEnclosure elements, performance is unchanged. The parsing logic uses the same BeautifulSoup traversal pattern as existing elements.


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests.
- [ ] No, I am a very confident individual.


### Steps to Test
1. Run the test suite: `python -m pytest tests/test_pyPodcastParser.py::TestAlternateEnclosureFeed -v`
2. Parse a feed with alternateEnclosure elements (test feed included: `tests/test_feeds/alternate_enclosure.rss`)
3. Access `item.alternate_enclosures` to get list of alternate media versions
4. Verify each enclosure has `type`, `length`, `bitrate`, `sources`, etc.
5. Confirm standard `item.enclosure_url` still works for backward compatibility

## Quality Assurance and Verifications
Looking for screenshots, screen recordings, honorable pledges.

## Documentation Updated
- [ ] Yes
- [x] No, documentation is for the weak. 
