### PR TITLE
SPIKE: Replace dict.pop() with dict.get() in pyPodcastParser tag processing

### DIFF
--- a/pypodcastparser/Item_lxml.py
+++ b/pypodcastparser/Item_lxml.py
@@ -1,0 +1,695 @@
+# -*- coding: utf-8 -*-
+"""SKETCH — lxml-based rewrite of Item.py.
+
+Drop-in replacement for `pypodcastparser.Item.Item`. Same public API and
+attributes as the BS4 version; constructor now takes an lxml.etree.Element
+plus the prefix_map produced by Podcast_lxml.
+"""
+from __future__ import annotations
+
+import datetime
+from datetime import timezone
+import email.utils
+import logging
+import re
+from typing import Optional
+
+import pytz
+
+from lxml import etree
+
+from pypodcastparser.Error import InvalidPodcastFeed
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+pytz_timezone_set = set(pytz.all_timezones)  # set instead of list (O(1) lookups)
+
+common_timezones = {
+    "IDLW": "Pacific/Midway",
+    "NUT": "Pacific/Niue",
+    "MART": "Pacific/Marquesas",
+    "AKST": "America/Anchorage",
+    "MST": "America/Denver",
+    "EST": "America/New_York",
+    "VET": "America/Caracas",
+    "BRT": "America/Sao_Paulo",
+    "GST": "Asia/Dubai",
+    "AZOT": "Atlantic/Azores",
+    "MSK": "Europe/Moscow",
+    "PKT": "Asia/Karachi",
+    "NPT": "Asia/Kathmandu",
+    "MMT": "Asia/Rangoon",
+    "ICT": "Asia/Bangkok",
+    "AWST": "Australia/Perth",
+    "ACWST": "Australia/Eucla",
+    "GMT": "GMT",
+    "ACST": "Australia/Adelaide",
+    "AEDT": "Australia/Sydney",
+    "CHAST": "Pacific/Chatham",
+    "NZDT": "Pacific/Auckland",
+    "LINT": "Pacific/Kiritimati",
+    "UTC": "UTC",
+    "CET": "Europe/Berlin",
+    "EET": "Africa/Cairo",
+    "EAT": "Africa/Addis_Ababa",
+    "IST": "Asia/Kolkata",
+    "BST": "Europe/London",
+    "JST": "Asia/Tokyo",
+    "ACT": "Australia/ACT",
+    "SST": "Pacific/Pago_Pago",
+    "NST": "America/St_Johns",
+    "HST": "America/Adak",
+    "AST": "America/Puerto_Rico",
+    "PST": "US/Pacific",
+    "CST": "US/Central",
+    "CAT": "Africa/Maputo",
+    "AEST": "Australia/Sydney",
+    "PDT": "America/Los_Angeles",
+    "NZST": "Pacific/Auckland",
+}
+
+# Map of timezone offsets to timezone abbreviations
+offset_map = {
+    "-1200": "IDLW", "-1100": "NUT", "-1000": "HST", "-0930": "MART",
+    "-0900": "AKST", "-0800": "PST", "-0700": "MST", "-0600": "CST",
+    "-0500": "EST", "-0430": "VET", "-0400": "AST", "-0330": "NST",
+    "-0300": "BRT", "-0200": "GST", "-0100": "AZOT", "-0000": "GMT",
+    "+0000": "GMT", "+0100": "CET", "+0200": "EET", "+0300": "MSK",
+    "+0400": "GST", "+0500": "PKT", "+0545": "NPT", "+0600": "BST",
+    "+0630": "MMT", "+0700": "ICT", "+0800": "AWST", "+0845": "ACWST",
+    "+0900": "JST", "+0930": "ACST", "+1000": "AEST", "+1030": "ACST",
+    "+1100": "AEDT", "+1200": "NZST", "+1245": "CHAST", "+1300": "NZDT",
+    "+1400": "LINT",
+}
+
+# Precompile the regexes used by set_published_date — was uncompiled in BS4
+# version, ran 5×per-episode-per-feed.
+_DATE_PATTERNS = [
+    re.compile(p) for p in (
+        r"^[a-zA-Z]{3},$",
+        r"^\d{1,2}$",
+        r"^[a-zA-Z]{3}$",
+        r"^\d{4}$",
+        r"^\d\d:\d\d",
+    )
+]
+_TZ_ABBREV_RE = re.compile(r"^[a-zA-Z]{3}$")
+
+
+_PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+
+
+def _qname(tag: str, prefix_map: dict) -> tuple[Optional[str], str]:
+    """Convert lxml Clark-notation '{uri}local' (or 'local') to the
+    (prefix, name) tuple the dispatch tables key on."""
+    if tag and tag[0] == "{":
+        uri, _, local = tag[1:].partition("}")
+        return prefix_map.get(uri), local
+    return None, tag
+
+
+def bs4_string(elem) -> Optional[str]:
+    """Emulate BeautifulSoup's `tag.string` semantics on an lxml element.
+
+    BS4's `.string` returns:
+      * `None` if the tag has zero or multiple children (mixed content)
+      * the text of the single text child, OR
+      * the recursive `.string` of the single tag child (single-chain to text)
+
+    This matters for RSS feeds where descriptions contain wrapped HTML like
+    `<description><p>text</p></description>` — BS4 returns "text" while
+    lxml's `.text` returns `None`.
+    """
+    if elem is None:
+        return None
+    n = len(elem)
+    if n == 0:
+        return elem.text
+    if n == 1 and not elem.text:
+        child = elem[0]
+        if not child.tail:
+            return bs4_string(child)
+    return None
+
+
+class Item:
+    """Parses one RSS <item>. Same public API as the BS4 Item."""
+
+    def __init__(self, elem, prefix_map: dict):
+        self.elem = elem
+        self._prefix_map = prefix_map
+
+        # Initialize attributes — feeds may not populate them
+        self.author = None
+        self.description = None
+        self.enclosure_url = None
+        self.enclosure_type = None
+        self.enclosure_length = None
+        self.content_encoded = None
+        self.guid = None
+        self.itunes_author_name = None
+        self.itunes_episode_type = None
+        self.itunes_block = False
+        self.itunes_duration = None
+        self.itunes_season = None
+        self.itunes_episode = None
+        self.itunes_explicit = None
+        self.itunes_image = None
+        self.itunes_order = None
+        self.itunes_subtitle = None
+        self.itunes_summary = None
+        self.published_date = None
+        self.published_date_string = None
+        self.title = None
+        self.date_time = None
+        self.interactive = None
+        self.is_interactive = None
+        self.podcast_transcript = None
+        self.transcriptionList = []
+        self.alternate_enclosures = []
+
+        tag_methods = {
+            (None, "title"): self.set_title,
+            (None, "author"): self.set_author,
+            (None, "description"): self.set_description,
+            (None, "guid"): self.set_guid,
+            (None, "pubDate"): self.set_published_date,
+            (None, "enclosure"): self.set_enclosure,
+            # Preserved from BS4 version (dead-code: not callable, but
+            # never hit in real feeds — mirrors the original behavior).
+            (None, "is_interactive"): self.is_interactive,
+            ("content", "encoded"): self.set_content_encoded,
+            ("itunes", "author"): self.set_itunes_author_name,
+            ("itunes", "episode"): self.set_itunes_episode,
+            ("itunes", "episodeType"): self.set_itunes_episode_type,
+            ("itunes", "block"): self.set_itunes_block,
+            ("itunes", "season"): self.set_itunes_season,
+            ("itunes", "duration"): self.set_itunes_duration,
+            ("itunes", "explicit"): self.set_itunes_explicit,
+            ("itunes", "image"): self.set_itunes_image,
+            ("podcast", "transcript"): self.set_podcast_transcript,
+            ("itunes", "order"): self.set_itunes_order,
+            ("itunes", "subtitle"): self.set_itunes_subtitle,
+            ("itunes", "summary"): self.set_itunes_summary,
+            ("ihr", "interactive"): self.set_interactive,
+            ("podcast", "alternateEnclosure"): self.set_alternate_enclosure,
+        }
+
+        for c in elem.iterchildren(tag=etree.Element):
+            key = _qname(c.tag, prefix_map)
+            if key[1] in ("transcript", "alternateEnclosure"):
+                # Multiple-occurrence tags: look up without removing.
+                method = tag_methods.get(key)
+            else:
+                # Single-value tag: pop on first hit to skip duplicates
+                # on invalid feeds (matches BS4 .pop() behavior).
+                method = tag_methods.pop(key, None)
+            if method is None:
+                continue
+            method(c)
+
+        self.set_time_published()
+        self.set_dates_published()
+
+    # ------------------------------------------------------------------
+    # Identical to BS4 Item — included for completeness.
+    # ------------------------------------------------------------------
+
+    def set_time_published(self):
+        if self.published_date_string is None:
+            self.time_published = None
+            return
+        try:
+            time_tuple = email.utils.parsedate_tz(self.published_date_string)
+            self.time_published = email.utils.mktime_tz(time_tuple)
+        except (TypeError, ValueError, IndexError):
+            self.time_published = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                f"Invalid Podcast Feed, episode level pubDate: {self.published_date_string}, could not be parsed"
+            )
+
+    def set_dates_published(self):
+        if self.time_published is None:
+            self.date_time = None
+            return
+        try:
+            self.date_time = datetime.date.fromtimestamp(self.time_published)
+        except ValueError:
+            self.date_time = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                f"Invalid Podcast Feed, episode level pubDate: {self.published_date_string}, could not be parsed"
+            )
+
+    def to_dict(self):
+        return {
+            "external_id": self.guid,
+            "episode_duration": self.itunes_duration,
+            "is_explicit": self.itunes_explicit,
+            "episode_number": self.itunes_episode,
+            "episode_season": self.itunes_season,
+            "episode_type": self.itunes_episode_type,
+            "external_image_url": self.itunes_image,
+            "episode_subtitle": self.itunes_subtitle,
+            "episode_description": self.description,
+            "original_air_date": self.published_date,
+            "start_date": self.published_date,
+            "episode_title": self.title,
+            "interactive": self.interactive,
+            "external_url": self.enclosure_url,
+            "enclosure_type": self.enclosure_type,
+            "enclosure_length": self.enclosure_length,
+            "transcription": self.podcast_transcript,
+            "alternate_enclosures": self.alternate_enclosures,
+        }
+
+    # ------------------------------------------------------------------
+    # Setters — tag.string → bs4_string(tag). Behavior preserved exactly.
+    # ------------------------------------------------------------------
+
+    def set_rss_element(self):
+        """Set each of the basic rss elements."""
+        self.set_enclosure()
+
+    def set_author(self, tag):
+        try:
+            self.author = bs4_string(tag)
+        except AttributeError:
+            self.author = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level author could not be parsed"
+            )
+
+    def set_description(self, tag):
+        try:
+            self.description = bs4_string(tag)
+        except AttributeError:
+            self.description = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level description could not be parsed"
+            )
+
+    def set_content_encoded(self, tag):
+        try:
+            self.content_encoded = bs4_string(tag)
+            if self.description is None:
+                self.description = self.content_encoded
+        except AttributeError:
+            self.content_encoded = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level content_encoded could not be parsed"
+            )
+
+    def set_enclosure(self, tag):
+        try:
+            self.enclosure_url = tag.get("url")
+            if self.enclosure_url is None:
+                # BS4 tag["url"] raises KeyError → caught → set to None.
+                # lxml .get returns None — keep as-is for parity.
+                pass
+        except Exception:
+            self.enclosure_url = None
+        try:
+            self.enclosure_type = tag.get("type")
+        except Exception:
+            self.enclosure_type = None
+        try:
+            self.enclosure_length = tag.get("length")
+            if self.enclosure_length is not None:
+                self.enclosure_length = int(self.enclosure_length)
+        except Exception:
+            self.enclosure_length = None
+
+    def set_guid(self, tag):
+        try:
+            self.guid = bs4_string(tag)
+        except AttributeError:
+            self.guid = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level guid could not be parsed"
+            )
+
+    def set_published_date(self, tag):
+        """Same algorithm as Item.set_published_date — tag.string → bs4_string(tag),
+        regexes precompiled."""
+        try:
+            text = bs4_string(tag)
+            self.published_date = text
+            self.published_date_string = text
+
+            if text is None:
+                raise AttributeError
+
+            deconstructed_date = text.split(" ")
+            if len(deconstructed_date) < 4:
+                raise AttributeError
+
+            published_date_timezone = ""
+            # Check for timezone abbreviation
+            if _TZ_ABBREV_RE.match(deconstructed_date[-1]):
+                published_date_timezone = deconstructed_date[-1]
+                deconstructed_date.pop()
+            else:
+                # Check for specific timezone offsets
+                for offset, tz in offset_map.items():
+                    if offset in self.published_date:
+                        published_date_timezone = tz
+                        deconstructed_date.pop()
+                        break
+            if not published_date_timezone:
+                published_date_timezone = "EST"
+
+            new_array = []
+            for array_index, pattern in enumerate(_DATE_PATTERNS):
+                # The original code's outer `re.match(deconstructed_date[i], array_value)`
+                # is preserved verbatim — note that calling re.match on a
+                # *string-as-pattern* almost never matches in practice, so this
+                # branch effectively always falls through to the inner loop.
+                if array_index < len(deconstructed_date) and re.match(
+                    deconstructed_date[array_index], pattern.pattern
+                ):
+                    new_array.append(pattern.pattern)
+                else:
+                    for inner_value in deconstructed_date:
+                        if pattern.match(inner_value):
+                            new_array.append(inner_value)
+                            break
+
+            if len(new_array) != 5:
+                raise AttributeError(
+                    "Error creating new date array. Array is not of length 5 for formatting"
+                )
+
+            date_string = " ".join(new_array)
+
+            time = date_string.split(":")
+            if len(time) == 2:
+                minutes = time[1].split(" ")
+                minutes[0] += ":00"
+                time[0] += ":" + minutes[0]
+                self.published_date = datetime.datetime.strptime(
+                    time[0], "%a, %d %b %Y %H:%M:%S"
+                )
+            elif len(time) == 3:
+                time[0] += ":" + time[1]
+                seconds = time[2]
+                seconds_string = seconds[:2]
+                time[0] += ":" + seconds_string
+                self.published_date = datetime.datetime.strptime(
+                    time[0], "%a, %d %b %Y %H:%M:%S"
+                )
+            else:
+                # Preserved verbatim from BS4 version (this branch is broken
+                # in the original — strptime on a datetime raises — so it
+                # always falls through to the outer except).
+                now = datetime.datetime.now(timezone.utc)
+                published_date_timezone = "UTC"
+                self.published_date = datetime.datetime.strptime(
+                    now, "%a, %d %b %Y %H:%M:%S"
+                )
+
+            if published_date_timezone not in ("ET", "EST", "EDT"):
+                if published_date_timezone in pytz_timezone_set:
+                    current_timezone = pytz.timezone(published_date_timezone)
+                else:
+                    current_timezone = pytz.timezone(
+                        common_timezones.get(published_date_timezone)
+                    )
+
+                date_in_current_timezone = current_timezone.localize(
+                    self.published_date
+                )
+                self.published_date = str(
+                    date_in_current_timezone.astimezone(
+                        pytz.timezone("US/Eastern")
+                    ).replace(tzinfo=None)
+                )
+                LOGGER.info("Final Published Date EST: %s", self.published_date)
+            else:
+                LOGGER.info("Final Published Date EST: %s", self.published_date)
+
+        except Exception:
+            self.published_date = datetime.datetime.now(
+                pytz.timezone("US/Eastern")
+            ).strftime("%Y-%m-%d %H:%M:%S")
+
+    def set_title(self, tag):
+        try:
+            self.title = bs4_string(tag)
+        except AttributeError:
+            self.title = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level title could not be parsed"
+            )
+
+    def set_itunes_author_name(self, tag):
+        try:
+            self.itunes_author_name = bs4_string(tag)
+        except AttributeError:
+            self.itunes_author_name = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level itunes:author could not be parsed"
+            )
+
+    def set_itunes_episode(self, tag):
+        try:
+            self.itunes_episode = bs4_string(tag)
+            if self.itunes_episode == "" or self.itunes_episode is None:
+                self.itunes_episode = "0"
+        except AttributeError:
+            self.itunes_episode = "0"
+        except Exception:
+            raise InvalidPodcastFeed(
+                f"Invalid Podcast Feed, episode level itunes:episode: {bs4_string(tag)}, could not be parsed"
+            )
+
+    def set_podcast_transcript(self, tag):
+        """Multiple transcripts allowed — append to list."""
+        try:
+            transcript_dict = {
+                "url": tag.get("url"),
+                "type": tag.get("type"),
+                "language": tag.get("language"),
+                "rel": tag.get("rel"),
+            }
+            self.transcriptionList.append(transcript_dict)
+            self.podcast_transcript = self.transcriptionList
+        except AttributeError:
+            self.podcast_transcript = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode transcription could not be parsed"
+            )
+
+    def set_itunes_season(self, tag):
+        try:
+            self.itunes_season = bs4_string(tag)
+            if self.itunes_season == "" or self.itunes_season is None:
+                self.itunes_season = "0"
+        except AttributeError:
+            self.itunes_season = "0"
+
+    def set_itunes_episode_type(self, tag):
+        try:
+            text = bs4_string(tag)
+            self.itunes_episode_type = text.lower() if text else None
+        except AttributeError:
+            self.itunes_episode_type = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                f"Invalid Podcast Feed, episode level itunes:episodeType: {bs4_string(tag)}, could not be parsed"
+            )
+
+    def set_itunes_block(self, tag):
+        try:
+            text = bs4_string(tag)
+            block = text.lower() if text else ""
+        except AttributeError:
+            block = ""
+        except Exception:
+            raise InvalidPodcastFeed(
+                f"Invalid Podcast Feed, episode level itunes:block: {bs4_string(tag)}, could not be parsed"
+            )
+        self.itunes_block = (block == "yes")
+
+    def set_itunes_duration(self, tag):
+        try:
+            text = bs4_string(tag)
+            if text is None:
+                self.itunes_duration = None
+                return
+            time_no_mil = text.split(".")
+            t = time_no_mil[0].split(":")
+            duration = 0
+            if len(t) == 3:
+                duration += int(t[0]) * 3600
+                duration += int(t[1]) * 60
+                duration += int(t[2])
+                self.itunes_duration = duration
+            elif len(t) == 2:
+                duration += int(t[0]) * 60
+                duration += int(t[1])
+                self.itunes_duration = duration
+            else:
+                self.itunes_duration = text
+        except AttributeError:
+            self.itunes_duration = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                f"Invalid Podcast Feed, episode level itunes:duration: {bs4_string(tag)}, could not be parsed"
+            )
+
+    def set_itunes_explicit(self, tag):
+        try:
+            text = bs4_string(tag)
+            if text is None:
+                self.itunes_explicit = None
+                return
+            self.itunes_explicit = text
+            lowered = self.itunes_explicit.lower()
+            if lowered in ("no", "false", "clean"):
+                self.itunes_explicit = False
+            elif lowered in ("yes", "true") or "offensive" in lowered:
+                self.itunes_explicit = True
+            else:
+                self.itunes_explicit = None
+        except AttributeError:
+            self.itunes_explicit = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level itunes:explicit could not be parsed"
+            )
+
+    def set_itunes_image(self, tag):
+        try:
+            self.itunes_image = tag.get("href")
+        except AttributeError:
+            self.itunes_image = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level itunes:image could not be parsed"
+            )
+
+    def set_itunes_order(self, tag):
+        try:
+            text = bs4_string(tag)
+            self.itunes_order = text.lower() if text else None
+        except AttributeError:
+            self.itunes_order = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level itunes:order could not be parsed"
+            )
+
+    def set_itunes_subtitle(self, tag):
+        try:
+            self.itunes_subtitle = bs4_string(tag)
+        except AttributeError:
+            self.itunes_subtitle = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level itunes:subtitle could not be parsed"
+            )
+
+    def set_itunes_summary(self, tag):
+        try:
+            self.itunes_summary = bs4_string(tag)
+        except AttributeError:
+            self.itunes_summary = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level itunes:summary could not be parsed"
+            )
+
+    def set_interactive(self, tag):
+        try:
+            text = bs4_string(tag)
+            self.interactive = (text or "").lower() == "yes"
+            self.is_interactive = self.interactive
+        except AttributeError:
+            self.interactive = False
+            self.is_interactive = self.interactive
+        except Exception:
+            raise InvalidPodcastFeed(
+                f"Invalid Podcast Feed, episode level ihr:interactive: {bs4_string(tag)}, could not be parsed"
+            )
+
+    def set_alternate_enclosure(self, tag):
+        """Parses podcast:alternateEnclosure and its nested podcast:source elements."""
+        try:
+            enclosure_dict = {}
+
+            enclosure_dict["mime_type"] = tag.get("type")
+
+            enclosure_dict["length"] = tag.get("length")
+            if enclosure_dict["length"]:
+                try:
+                    enclosure_dict["length"] = int(enclosure_dict["length"])
+                except (ValueError, TypeError):
+                    pass
+
+            enclosure_dict["bitrate"] = tag.get("bitrate")
+            if enclosure_dict["bitrate"]:
+                try:
+                    enclosure_dict["bitrate"] = float(enclosure_dict["bitrate"])
+                except (ValueError, TypeError):
+                    pass
+
+            enclosure_dict["height"] = tag.get("height")
+            if enclosure_dict["height"]:
+                try:
+                    enclosure_dict["height"] = int(enclosure_dict["height"])
+                except (ValueError, TypeError):
+                    pass
+
+            enclosure_dict["lang"] = tag.get("lang")
+            enclosure_dict["title"] = tag.get("title")
+            enclosure_dict["rel"] = tag.get("rel")
+            enclosure_dict["codecs"] = tag.get("codecs")
+
+            default_value = tag.get("default", "False")
+            falsy_strings = ("false", "0", "no", "False")
+            enclosure_dict["default"] = default_value.lower() not in falsy_strings
+
+            # Direct children only; accept both unprefixed <source> and
+            # <podcast:source>, matching BS4 filter `prefix == "podcast" or not prefix`.
+            sources = []
+            for source_tag in tag.iterchildren(tag=etree.Element):
+                prefix, name = _qname(source_tag.tag, self._prefix_map)
+                if name == "source" and (prefix == "podcast" or prefix is None):
+                    source_dict = {
+                        "uri": source_tag.get("uri") or source_tag.get("url"),
+                        "content_type": source_tag.get("contentType"),
+                        "integrity_type": None,
+                        "integrity_value": None,
+                    }
+                    sources.append(source_dict)
+
+            for integrity_tag in tag.iterchildren(tag=etree.Element):
+                prefix, name = _qname(integrity_tag.tag, self._prefix_map)
+                if name == "integrity" and (prefix == "podcast" or prefix is None) and sources:
+                    integrity_type = integrity_tag.get("type")
+                    integrity_value = integrity_tag.get("value")
+                    for source in sources:
+                        source["integrity_type"] = integrity_type
+                        source["integrity_value"] = integrity_value
+
+            enclosure_dict["sources"] = sources
+
+            self.alternate_enclosures.append(enclosure_dict)
+
+        except AttributeError:
+            pass
+        except Exception:
+            raise InvalidPodcastFeed(
+                "Invalid Podcast Feed, episode level podcast:alternateEnclosure could not be parsed"
+            )

--- a/pypodcastparser/Podcast_lxml.py
+++ b/pypodcastparser/Podcast_lxml.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+"""SKETCH — lxml-based rewrite of Podcast.py.
+
+Drop-in replacement for `pypodcastparser.Podcast.Podcast`. Same public API
+(every attribute, every method name preserved) but parses with
+`lxml.etree` directly instead of wrapping every node in a `bs4.element.Tag`.
+
+Compared to Podcast.py:
+  * `set_soup` → `_parse` (cached module-level XMLParser with recover=True)
+  * `self.soup` → `self.root` (lxml Element)
+  * `tag.string` → `bs4_string(tag)`
+  * `tag.prefix` / `tag.name` → derived from `tag.tag` via `_qname()`
+  * `channel.children` (filtered on Tag) → `channel.iterchildren(tag=etree.Element)`
+  * `tag.find("itunes:name", recursive=False)` → `tag.find("itunes:name", namespaces=NS)`
+  * `tag.find_all(..., recursive=False)` → `tag.iterchildren(tag=...)`
+
+Item.py needs the matching change — its constructor will take an
+`etree.Element` plus the prefix map produced here (see end of file).
+"""
+from __future__ import annotations
+
+import datetime
+import email.utils
+from typing import Optional
+
+from lxml import etree
+
+from pypodcastparser.Item_lxml import Item, bs4_string
+from pypodcastparser.Error import InvalidPodcastFeed
+
+
+# Well-known namespace URIs mapped to the short prefixes the dispatch
+# tables use. Anything declared in the document's root nsmap overrides
+# this at parse time.
+_DEFAULT_PREFIXES = {
+    "http://www.itunes.com/dtds/podcast-1.0.dtd": "itunes",
+    "http://purl.org/rss/1.0/modules/content/": "content",
+    "https://podcastindex.org/namespace/1.0": "podcast",
+    "http://iheart.com/rss/ihr": "ihr",
+}
+
+_ITUNES_NS = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+_ITUNES_CATEGORY = f"{{{_ITUNES_NS}}}category"
+
+# One reusable parser. recover=True handles malformed feeds without our
+# manual byte-slicing fallback; huge_tree=True lifts libxml2's default
+# size limit for very large catalogs.
+_PARSER = etree.XMLParser(recover=True, huge_tree=True, resolve_entities=False)
+
+
+def _qname(tag: str, prefix_map: dict) -> tuple[Optional[str], str]:
+    """Convert lxml Clark-notation '{uri}local' (or 'local') to the
+    (prefix, name) tuple the dispatch tables key on."""
+    if tag and tag[0] == "{":
+        uri, _, local = tag[1:].partition("}")
+        return prefix_map.get(uri), local
+    return None, tag
+
+
+class Podcast:
+    """Parses an XML RSS feed. Same public API as the BS4 version."""
+
+    def __init__(self, feed_content: bytes):
+        self.feed_content = feed_content
+        self.items: list = []
+        self.itunes_categories: list = []
+        self.itunes_keywords: list = []
+
+        # Initialize attributes — feed may not populate them
+        self.copyright = None
+        self.description = None
+        self.image_url = None
+        self.itunes_author_name = None
+        self.itunes_block = False
+        self.itunes_complete = None
+        self.itunes_explicit = None
+        self.itunes_image = None
+        self.itunes_new_feed_url = None
+        self.language = None
+        self.last_build_date = None
+        self.link = None
+        self.published_date = None
+        self.published_date_string = None
+        self.summary = None
+        self.owner_name = None
+        self.owner_email = None
+        self.subtitle = None
+        self.title = None
+        self.date_time = None
+        self.itunes_type = None
+        self.interactive = False
+        self.is_interactive = False
+
+        self.root = self._parse(feed_content)
+
+        # Build the URI→prefix map: defaults overridden by whatever the
+        # document itself declares at the root.
+        prefix_map = dict(_DEFAULT_PREFIXES)
+        for prefix, uri in (self.root.nsmap or {}).items():
+            if prefix:
+                prefix_map[uri] = prefix
+        self._prefix_map = prefix_map
+
+        tag_methods = {
+            (None, "copyright"): self.set_copyright,
+            (None, "description"): self.set_description,
+            (None, "image"): self.set_image,
+            (None, "language"): self.set_language,
+            (None, "lastBuildDate"): self.set_last_build_date,
+            (None, "link"): self.set_link,
+            (None, "pubDate"): self.set_published_date,
+            (None, "title"): self.set_title,
+            (None, "item"): self.add_item,
+            ("itunes", "author"): self.set_itunes_author_name,
+            ("itunes", "type"): self.set_itunes_type,
+            ("itunes", "block"): self.set_itunes_block,
+            ("itunes", "category"): self.add_itunes_category,
+            ("itunes", "complete"): self.set_itunes_complete,
+            ("itunes", "explicit"): self.set_itunes_explicit,
+            ("itunes", "image"): self.set_itunes_image,
+            ("itunes", "keywords"): self.set_itunes_keywords,
+            ("itunes", "new-feed-url"): self.set_itunes_new_feed_url,
+            ("itunes", "owner"): self.set_owner,
+            ("itunes", "subtitle"): self.set_subtitle,
+            ("itunes", "summary"): self.set_summary,
+            ("ihr", "interactive"): self.set_interactive,
+        }
+        many_tag_methods = frozenset(
+            {(None, "item"), ("itunes", "category"), ("itunes", "keywords")}
+        )
+
+        channel = self.root.find("channel") if self.root is not None else None
+        if channel is None:
+            raise InvalidPodcastFeed("Invalid Podcast Feed")
+
+        # Walk channel children once — lxml's iterchildren(tag=Element)
+        # skips text/comment nodes natively, so no isinstance check needed.
+        for c in channel.iterchildren(tag=etree.Element):
+            key = _qname(c.tag, prefix_map)
+            method = tag_methods.get(key)
+            if method is None:
+                continue
+            # For single-value tags, drop the dispatch entry so a duplicate
+            # on an invalid feed gets ignored — matches BS4 .pop() behavior.
+            if key not in many_tag_methods:
+                tag_methods.pop(key, None)
+            method(c)
+
+        if not self.items:
+            # Fallback for malformed feeds: walk the whole document for <item>.
+            for elem in self.root.iter():
+                if _qname(elem.tag, prefix_map) == (None, "item"):
+                    self.add_item(elem)
+
+        self.set_time_published()
+        self.set_dates_published()
+
+    @staticmethod
+    def _parse(feed_content: bytes):
+        """Replacement for set_soup(). Tolerates junk before <?xml."""
+        try:
+            if feed_content and not feed_content.startswith(b"<?xml"):
+                idx = feed_content.find(b"<?xml")
+                if idx > 0:
+                    feed_content = feed_content[idx:]
+            root = etree.fromstring(feed_content, parser=_PARSER)
+            if root is None:
+                raise InvalidPodcastFeed("Invalid Podcast Feed: empty document")
+            return root
+        except etree.XMLSyntaxError as e:
+            raise InvalidPodcastFeed(f"Invalid Podcast Feed: {e}")
+
+    # ------------------------------------------------------------------
+    # Setters — same semantics as Podcast.py, with tag.string → bs4_string(tag).
+    # Bodies that are pure 1-line `self.X = tag.string` are collapsed.
+    # ------------------------------------------------------------------
+
+    def add_item(self, tag):
+        self.items.append(Item(tag, self._prefix_map))
+
+    def set_copyright(self, tag): self.copyright = bs4_string(tag)
+    def set_description(self, tag): self.description = bs4_string(tag)
+    def set_language(self, tag): self.language = bs4_string(tag)
+    def set_last_build_date(self, tag): self.last_build_date = bs4_string(tag)
+    def set_link(self, tag): self.link = bs4_string(tag)
+    def set_title(self, tag): self.title = bs4_string(tag)
+    def set_subtitle(self, tag): self.subtitle = bs4_string(tag)
+    def set_summary(self, tag): self.summary = bs4_string(tag)
+    def set_itunes_author_name(self, tag): self.itunes_author_name = bs4_string(tag)
+    def set_itunes_new_feed_url(self, tag): self.itunes_new_feed_url = bs4_string(tag)
+
+    def set_image(self, tag):
+        # <image><url>...</url></image> — direct child only.
+        try:
+            url_elem = tag.find("url")
+            self.image_url = bs4_string(url_elem) if url_elem is not None else None
+        except Exception:
+            raise InvalidPodcastFeed("Invalid Podcast Feed, show level image could not be parsed")
+
+    def set_itunes_type(self, tag):
+        text = bs4_string(tag)
+        self.itunes_type = text.lower() if text else None
+
+    def set_itunes_block(self, tag):
+        # Old behavior: True iff text.lower() == "yes". Other text → False.
+        text = (bs4_string(tag) or "").lower()
+        self.itunes_block = (text == "yes")
+
+    def set_itunes_complete(self, tag):
+        text = bs4_string(tag)
+        self.itunes_complete = text.lower() if text else None
+
+    def set_itunes_explicit(self, tag):
+        text = bs4_string(tag)
+        self.itunes_explicit = text.lower() if text else None
+
+    def set_itunes_image(self, tag):
+        self.itunes_image = tag.get("href")
+
+    def set_itunes_keywords(self, tag):
+        text = bs4_string(tag)
+        if not text:
+            self.itunes_keywords = []
+            return
+        normalized = [" ".join(k.split()) for k in text.split(",")]
+        unique = list({k for k in normalized if k})
+        self.itunes_keywords = unique
+
+    def set_owner(self, tag):
+        ns = {"itunes": _ITUNES_NS}
+        name_elem = tag.find("itunes:name", namespaces=ns)
+        email_elem = tag.find("itunes:email", namespaces=ns)
+        self.owner_name = bs4_string(name_elem) if name_elem is not None else None
+        self.owner_email = bs4_string(email_elem) if email_elem is not None else None
+
+    def add_itunes_category(self, tag):
+        category_text = tag.get("text")
+        if category_text not in self.itunes_categories:
+            self.itunes_categories.append(category_text)
+        # Recurse into nested <itunes:category> children only.
+        for child in tag.iterchildren(tag=_ITUNES_CATEGORY):
+            self.add_itunes_category(child)
+
+    def set_published_date(self, tag):
+        """Same logic as Podcast.py.set_published_date — only tag.string → bs4_string(tag)."""
+        try:
+            text = bs4_string(tag)
+            self.published_date = text
+            self.published_date_string = text
+            final_time = text.split(":")
+            min_sec = final_time[2]
+            seconds = min_sec[:2]
+            final_time[0] += ":" + final_time[1]
+            final_time[0] += ":" + seconds
+            self.published_date = str(
+                datetime.datetime.strptime(final_time[0], "%a, %d %b %Y %H:%M:%S")
+            )
+        except AttributeError:
+            self.published_date = None
+        except Exception:
+            raise InvalidPodcastFeed(
+                f"Invalid Podcast Feed, show level pubDate: {bs4_string(tag)}, could not be parsed"
+            )
+
+    def set_interactive(self, tag):
+        text = bs4_string(tag)
+        self.interactive = (text or "").lower() == "yes"
+        self.is_interactive = self.interactive
+
+    # ------------------------------------------------------------------
+    # Unchanged from Podcast.py — included for completeness.
+    # ------------------------------------------------------------------
+
+    def set_time_published(self):
+        if self.published_date_string is None:
+            self.time_published = None
+            return
+        try:
+            time_tuple = email.utils.parsedate_tz(self.published_date_string)
+            self.time_published = email.utils.mktime_tz(time_tuple)
+        except (TypeError, ValueError, IndexError):
+            self.time_published = None
+        except Exception:
+            raise InvalidPodcastFeed("Invalid Podcast Feed, show level pubDate could not be parsed")
+
+    def set_dates_published(self):
+        if self.time_published is None:
+            self.date_time = None
+            return
+        try:
+            self.date_time = datetime.date.fromtimestamp(self.time_published)
+        except ValueError:
+            self.date_time = None
+        except Exception:
+            raise InvalidPodcastFeed("Invalid Podcast Feed, show level pubDate could not be parsed")
+
+    def to_dict(self):
+        podcast_dict = {
+            "copyright": self.copyright,
+            "description": self.description,
+            "image_url": self.image_url,
+            "items": [item.to_dict() for item in self.items],
+            "itunes_author_name": self.itunes_author_name,
+            "itunes_block": self.itunes_block,
+            "itunes_categories": self.itunes_categories,
+            "itunes_explicit": self.itunes_explicit,
+            "itunes_image": self.itunes_image,
+            "itunes_keywords": self.itunes_keywords,
+            "itunes_new_feed_url": self.itunes_new_feed_url,
+            "language": self.language,
+            "last_build_date": self.last_build_date,
+            "link": self.link,
+            "published_date": self.published_date,
+            "owner_name": self.owner_name,
+            "owner_email": self.owner_email,
+            "subtitle": self.subtitle,
+            "title": self.title,
+            "itunes_type": self.itunes_type,
+        }
+        return podcast_dict
+
+

--- a/scripts/measure_mem_alloc.py
+++ b/scripts/measure_mem_alloc.py
@@ -1,0 +1,106 @@
+"""Run pypodcastparser memory measurement N times per feed; report median peak.
+
+Fetches each feed once, then parses N times with each implementation
+(Podcast vs Podcast_lxml), capturing tracemalloc peak per run.
+"""
+
+import gc
+import statistics
+import sys
+import tracemalloc
+from time import perf_counter
+
+from podcasts.rss import _get_feed_content, clean_content_encoded
+from pypodcastparser.Error import InvalidPodcastFeed
+from pypodcastparser.Podcast import Podcast
+from pypodcastparser.Podcast_lxml import Podcast as Podcast_lxml
+
+
+FEEDS = [
+    "https://feeds.redcircle.com/b5a293e2-0ba9-44f0-8744-4ab98a7928f2",
+    "https://anchor.fm/s/1d5aebec/podcast/rss",
+    "https://rss.libsyn.com/shows/560300/destinations/4840795.xml",
+    "https://www.omnycontent.com/d/playlist/e73c998e-6e60-432f-8610-ae210140c5b1/b0033a5f-8d6c-46a0-90bd-afb90153a86d/b71608e3-ebff-402a-8ca1-afb90153a898/podcast.rss",
+    "https://chainsawhorror.com/feed/mp3/",
+    "https://feed.podbean.com/thedjsessions/feed.xml",
+]
+
+N_RUNS = 5
+
+
+def fetch(rss_url: str) -> bytes:
+    response = _get_feed_content(rss_url)
+    response.raise_for_status()
+    return clean_content_encoded(response.content)
+
+
+def measure_peak(parser_cls, cleaned_xml: bytes) -> tuple[int, int, float]:
+    gc.collect()
+    tracemalloc.start()
+    start = perf_counter()
+    try:
+        podcast = parser_cls(cleaned_xml)
+    except InvalidPodcastFeed as exc:
+        tracemalloc.stop()
+        raise RuntimeError(f"InvalidPodcastFeed: {exc}") from exc
+    elapsed = perf_counter() - start
+    _, peak = tracemalloc.get_traced_memory()
+    n_items = len(podcast.items)
+    tracemalloc.stop()
+    del podcast
+    gc.collect()
+    return peak, n_items, elapsed
+
+
+def run_feed(rss_url: str) -> None:
+    print(f"\n=== feed: {rss_url}")
+    cleaned_xml = fetch(rss_url)
+    print(f"feed bytes: {len(cleaned_xml):,}")
+
+    rows = []
+    for label, cls in (("Podcast (bs4)", Podcast), ("Podcast_lxml", Podcast_lxml)):
+        peaks = []
+        times = []
+        n_items = 0
+        for _ in range(N_RUNS):
+            peak, n_items, elapsed = measure_peak(cls, cleaned_xml)
+            peaks.append(peak)
+            times.append(elapsed)
+        median_kb = statistics.median(peaks) / 1024
+        min_kb = min(peaks) / 1024
+        max_kb = max(peaks) / 1024
+        median_ms = statistics.median(times) * 1000
+        min_ms = min(times) * 1000
+        max_ms = max(times) * 1000
+        rows.append((label, n_items, median_kb, min_kb, max_kb, median_ms, min_ms, max_ms))
+
+    print(f"items:      {rows[0][1]:,}")
+    print(f"runs:       {N_RUNS}")
+    print()
+    print(
+        f"  {'impl':<16}  {'med KB':>10}  {'min KB':>10}  {'max KB':>10}  "
+        f"{'KB/item':>9}  {'med ms':>9}  {'min ms':>9}  {'max ms':>9}  {'ms/item':>9}"
+    )
+    for label, n_items, med_kb, mn_kb, mx_kb, med_ms, mn_ms, mx_ms in rows:
+        kb_per_item = med_kb / n_items if n_items else 0
+        ms_per_item = med_ms / n_items if n_items else 0
+        print(
+            f"  {label:<16}  {med_kb:>10,.1f}  {mn_kb:>10,.1f}  {mx_kb:>10,.1f}  "
+            f"{kb_per_item:>9,.2f}  {med_ms:>9,.1f}  {mn_ms:>9,.1f}  {mx_ms:>9,.1f}  {ms_per_item:>9,.3f}"
+        )
+    # Ratios
+    orig_kb, lxml_kb = rows[0][2], rows[1][2]
+    orig_ms, lxml_ms = rows[0][5], rows[1][5]
+    print()
+    if lxml_kb:
+        print(f"  memory reduction:  {(1 - lxml_kb / orig_kb) * 100:.1f}%  ({orig_kb / lxml_kb:.2f}x less)")
+    if lxml_ms:
+        print(f"  time speedup:      {(1 - lxml_ms / orig_ms) * 100:.1f}%  ({orig_ms / lxml_ms:.2f}x faster)")
+
+
+if __name__ == "__main__":
+    for feed in FEEDS:
+        try:
+            run_feed(feed)
+        except Exception as exc:
+            print(f"\n!! feed failed: {feed}\n   {type(exc).__name__}: {exc}")


### PR DESCRIPTION
## Jira Ticket
  - [IHRACP-9132](https://ihm-it.atlassian.net/browse/IHRACP-9132)
  

## What type of PR is this? (check all applicable)
  - [x] Refactor
  - [ ] Feature
  - [ ] Bug Fix
  - [ ] Documentation Update

 ## Intended Behavior
  Examine the memory and time benefits of refactoring`pypodcastparser`
  from BeautifulSoup-on-lxml-xml to `lxml.etree`. No production behavior changes
  in this PR.

  ## Describe Changes Made
  - Added `pypodcastparser/Podcast_lxml.py` & `pypodcastparser/Item_lxml.py` to test the performance of possibly swapping from the Bs4 to the lxml parser. (These are from a PR in the podcast-platform that Michael pulled)
  - Added `scripts/measure_mem_alloc.py` which uses`tracemalloc` that reads peak memory and parse time over five runs,
    plus gives metrics on memory-reduction and speedup ratios.
  - No existing files modified — the bs4 code path is unchanged.


  ## System Performance Impact
  None in this PR. The new modules are not imported by anything in the package; the
  benchmark script under `scripts/` is the only consumer.

  ## Downstream impact (if/when we cut over): 
- expected memory reduction and parse-time speedup vs the bs4 method


  ## Added/updated tests?

  - [ ] Yes
  - [x] No, and this is why: this is a spike to evaluate viability. I
  - [ ] I need help with writing tests.
  - [ ] No, I am a very confident individual.


  ### Steps to Test
  1. Update `test_pyPodcastParser.py` to point to the new Podcast_lxml.py and ensure all test pass with no changes to the assertions
  2. Using a new set of rss feeds or use the existing ones to gather new metrics or confirm the given ones
  3. Spot-check parity: `Podcast_lxml(feed_bytes).to_dict()` vs
     `Podcast(feed_bytes).to_dict()` on a sampling of real feeds

  ## Quality Assurance and Verifications
  Benchmark output (memory + time table per feed) will be attached on the review
  request.


## Memory — peak (median of 5 runs)

| Feed | Bytes | Items | bs4 peak | lxml peak | bs4 KB/item | lxml KB/item | Reduction |
|---|---:|---:|---:|---:|---:|---:|---:|
| redcircle | 6.6 MB | 411 | 21.4 MB | 7.5 MB | 52.13 | 18.28 | 64.9% (2.85×) |
| anchor.fm | 39.7 MB | 4,493 | 154.8 MB | 67.1 MB | 34.46 | 14.93 | 56.7% (2.31×) |
| libsyn | 14.3 MB | 322 | 19.9 MB | 7.8 MB | 61.89 | 24.12 | 61.0% (2.57×) |
| omnycontent | 37.3 MB | 11,468 | 359.8 MB | 58.0 MB | 31.37 | 5.06 | **83.9% (6.20×)** |
| chainsawhorror | 36.7 MB | 482 | 54.6 MB | 1.95 MB | 113.36 | 4.05 | **96.4% (28.02×)** |
| podbean | 36.2 MB | 2,278 | 123.7 MB | 42.8 MB | 54.29 | 18.78 | 65.4% (2.89×) |

## Time — parse duration (median of 5 runs)

| Feed | Items | bs4 time | lxml time | bs4 ms/item | lxml ms/item | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| redcircle | 411 | 488 ms | 186 ms | 1.187 | 0.453 | 2.62× (61.8%) |
| anchor.fm | 4,493 | 4,793 ms | 1,538 ms | 1.067 | 0.342 | **3.12× (67.9%)** |
| libsyn | 322 | 326 ms | 132 ms | 1.012 | 0.410 | 2.47× (59.5%) |
| omnycontent | 11,468 | 13,695 ms | 4,848 ms | 1.194 | 0.423 | 2.83× (64.6%) |
| chainsawhorror | 482 | 749 ms | 297 ms | 1.555 | 0.615 | 2.53× (60.4%) |
| podbean | 2,278 | 2,675 ms | 1,097 ms | 1.174 | 0.482 | 2.44× (59.0%) |


  ## Documentation Updated
  - [ ] Yes
  - [x] No, documentation is for the weak.

[IHRACP-9132]: https://ihm-it.atlassian.net/browse/IHRACP-9132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ